### PR TITLE
official_devices: update jd2019

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -130,7 +130,7 @@
         }
     },
     {
-        "name": "Lenovo Z5s",
+        "name": "Z5s",
         "brand": "Lenovo",
         "codename": "jd2019",
         "xda_thread": "https://forum.xda-developers.com/t/rom-11-dotos-r-v5-0-unofficial-for-lenovo-z5s-jd2019-26-2-2021.4230967/",


### PR DESCRIPTION
small fix to display "Lenovo Z5s" in website instead of "Lenovo Lenovo Z5s"